### PR TITLE
atp-803 make client it, secret, oath_url settable

### DIFF
--- a/src/AuthManager.php
+++ b/src/AuthManager.php
@@ -26,14 +26,21 @@ class AuthManager
      *
      * @var string
      */
-    protected $clientId;
+    protected $clientId = false;
 
     /**
      * Client secret
      *
      * @var string
      */
-    protected $clientSecret;
+    protected $clientSecret = false;
+
+    /**
+     * url
+     *
+     * @var string
+     */
+    protected $url = false;
 
     /**
      * Determine JWT is cached or not.
@@ -58,10 +65,6 @@ class AuthManager
     public function __construct(Client $client)
     {
         $this->client = $client;
-
-        $this->clientId = env('AUTH0_JWT_CLIENTID');
-
-        $this->clientSecret = env('AUTH0_JWT_CLIENTSECRET');
     }
 
     /**
@@ -105,6 +108,20 @@ class AuthManager
     }
 
     /**
+     * Get the client Id
+     *
+     * @return string
+     */
+    public function getClientId()
+    {
+        if (!$this->clientId) {
+            $this->clientId = env('AUTH0_JWT_CLIENTID');
+        }
+
+        return $this->clientId;
+    }
+
+    /**
      * Set client secret.
      *
      * @param string $clientSecret
@@ -115,6 +132,20 @@ class AuthManager
         $this->clientSecret = $clientSecret;
 
         return $this;
+    }
+
+    /**
+     * Get the client secret
+     *
+     * @return string
+     */
+    public function getClientSecret()
+    {
+        if (!$this->clientSecret) {
+            $this->clientSecret = env('AUTH0_JWT_CLIENTSECRET');
+        }
+
+        return $this->clientSecret;
     }
 
     /**
@@ -219,8 +250,8 @@ class AuthManager
     public function getOptions()
     {
         $options = [
-            'client_id' => $this->clientId,
-            'client_secret' => $this->clientSecret,
+            'client_id' => $this->getClientId(),
+            'client_secret' => $this->getClientSecret(),
             'audience' => $this->getAudience(),
             'grant_type' => env('AUTH0_GRANT_TYPE', 'client_credentials'),
         ];
@@ -235,16 +266,31 @@ class AuthManager
     }
 
     /**
+     * Set url.
+     *
+     * @param string $url
+     * @return $this
+     */
+    public function setUrl($url)
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
      * Get Auth0 OAuth URL
      *
      * @return string
      */
     public function getUrl()
     {
-        if (!$url = env('AUTH0_OAUTH_URL')) {
-            throw new Exception("Auth0 OAuth URL not set");
+        If (!$this->url) {
+            if (!$this->url = env('AUTH0_OAUTH_URL')) {
+                throw new Exception("Auth0 OAuth URL not set");
+            }
         }
 
-        return $url;
+        return $this->url;
     }
 }

--- a/src/AuthManager.php
+++ b/src/AuthManager.php
@@ -22,6 +22,20 @@ class AuthManager
     protected $audience;
 
     /**
+     * Client Id
+     *
+     * @var string
+     */
+    protected $clientId;
+
+    /**
+     * Client secret
+     *
+     * @var string
+     */
+    protected $clientSecret;
+
+    /**
      * Determine JWT is cached or not.
      *
      * @var string
@@ -38,12 +52,16 @@ class AuthManager
     /**
      * Constructor
      *
-     * @param \GuzzleHttp\Client  $client
+     * @param \GuzzleHttp\Client $client
      * @return void
      */
     public function __construct(Client $client)
     {
         $this->client = $client;
+
+        $this->clientId = env('AUTH0_JWT_CLIENTID');
+
+        $this->clientSecret = env('AUTH0_JWT_CLIENTSECRET');
     }
 
     /**
@@ -71,6 +89,32 @@ class AuthManager
         }
 
         return $this->audience;
+    }
+
+    /**
+     * Set client id.
+     *
+     * @param string $clientId
+     * @return $this
+     */
+    public function setClientId($clientId)
+    {
+        $this->clientId = $clientId;
+
+        return $this;
+    }
+
+    /**
+     * Set client secret.
+     *
+     * @param string $clientSecret
+     * @return $this
+     */
+    public function setClientSecret($clientSecret)
+    {
+        $this->clientSecret = $clientSecret;
+
+        return $this;
     }
 
     /**
@@ -159,7 +203,7 @@ class AuthManager
     /**
      * Decode GuzzleHttp response
      *
-     * @param \GuzzleHttp\Psr7\Response  $response
+     * @param \GuzzleHttp\Psr7\Response $response
      * @return mixed
      */
     public function decodeResponse(Response $response)
@@ -175,8 +219,8 @@ class AuthManager
     public function getOptions()
     {
         $options = [
-            'client_id' => env('AUTH0_JWT_CLIENTID'),
-            'client_secret' => env('AUTH0_JWT_CLIENTSECRET'),
+            'client_id' => $this->clientId,
+            'client_secret' => $this->clientSecret,
             'audience' => $this->getAudience(),
             'grant_type' => env('AUTH0_GRANT_TYPE', 'client_credentials'),
         ];

--- a/src/AuthManager.php
+++ b/src/AuthManager.php
@@ -26,21 +26,21 @@ class AuthManager
      *
      * @var string
      */
-    protected $clientId = false;
+    protected $clientId = null;
 
     /**
      * Client secret
      *
      * @var string
      */
-    protected $clientSecret = false;
+    protected $clientSecret = null;
 
     /**
      * url
      *
      * @var string
      */
-    protected $url = false;
+    protected $url = null;
 
     /**
      * Determine JWT is cached or not.

--- a/tests/AuthManagerTest.php
+++ b/tests/AuthManagerTest.php
@@ -197,4 +197,26 @@ class AuthManagerTest extends TestCase
 
         $this->assertEquals('foo', $auth->getAudience());
     }
+
+    /**
+     * @test
+     * @group AuthManager
+     */
+    public function couldSetClientId()
+    {
+        $auth = (new AuthManager(new Client))->setAudience('foo')->setClientId('clientId');
+
+        $this->assertEquals('clientId', $auth->getOptions()['client_id']);
+    }
+
+    /**
+     * @test
+     * @group AuthManager
+     */
+    public function couldSetClientSecret()
+    {
+        $auth = (new AuthManager(new Client))->setAudience('foo')->setClientSecret('clientSecret');
+
+        $this->assertEquals('clientSecret', $auth->getOptions()['client_secret']);
+    }
 }

--- a/tests/AuthManagerTest.php
+++ b/tests/AuthManagerTest.php
@@ -213,10 +213,60 @@ class AuthManagerTest extends TestCase
      * @test
      * @group AuthManager
      */
+    public function shouldUseDefaultIfClientIdNotSet()
+    {
+        putenv('AUTH0_JWT_CLIENTID=client_id');
+
+        $auth = (new AuthManager(new Client))->setAudience('foo');
+
+        $this->assertEquals('client_id', $auth->getOptions()['client_id']);
+    }
+
+    /**
+     * @test
+     * @group AuthManager
+     */
     public function couldSetClientSecret()
     {
         $auth = (new AuthManager(new Client))->setAudience('foo')->setClientSecret('clientSecret');
 
         $this->assertEquals('clientSecret', $auth->getOptions()['client_secret']);
+    }
+
+    /**
+     * @test
+     * @group AuthManager
+     */
+    public function shouldUseDefaultIfClientSecretNotSet()
+    {
+        putenv('AUTH0_JWT_CLIENTSECRET=client_secret');
+
+        $auth = (new AuthManager(new Client))->setAudience('foo');
+
+        $this->assertEquals('client_secret', $auth->getOptions()['client_secret']);
+    }
+
+    /**
+     * @test
+     * @group AuthManager
+     */
+    public function couldSetUrl()
+    {
+        $auth = (new AuthManager(new Client))->setUrl('url');
+
+        $this->assertEquals('url', $auth->getUrl());
+    }
+
+    /**
+     * @test
+     * @group AuthManager
+     */
+    public function shouldUseDefaultIfUrlNotSet()
+    {
+        putenv('AUTH0_OAUTH_URL=oauth_url');
+
+        $auth = (new AuthManager(new Client))->setAudience('foo');
+
+        $this->assertEquals('oauth_url', $auth->getUrl());
     }
 }


### PR DESCRIPTION
atp-803 in order to enable yoda support two brands,  Yoda need set client it, secret, oath_url to access either CG or AT auth0 users